### PR TITLE
grpc/tls: able to use service authentication via PKI (TLS)

### DIFF
--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -36,5 +36,11 @@ type TLSConfig struct {
 }
 
 type GRPCListenerConfig struct {
-	Address string `json:"address"`
+	Address    string            `json:"address"`
+	ServicePKI *PKIServiceConfig `json:"service-pki,omitempty"`
+}
+
+type PKIServiceConfig struct {
+	KeyFile         string `json:"key-file"`
+	CertificateFile string `json:"certificate-file"`
 }


### PR DESCRIPTION
Allows for gRPC service to use TLS for service authentication.